### PR TITLE
fix(ci): fix clang build failure and DockerHub image ref errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,11 @@ jobs:
 
     strategy:
       matrix:
-        cc: [gcc, clang]
+        include:
+          - cc: gcc
+            extra_cflags: -Wno-error=maybe-uninitialized
+          - cc: clang
+            extra_cflags: ''
 
     steps:
       - name: Checkout repository
@@ -36,6 +40,6 @@ jobs:
           sudo apt-get install -y libusb-1.0-0-dev ${{ matrix.cc }}
 
       - name: Build with ${{ matrix.cc }}
-        run: make CC=${{ matrix.cc }} CFLAGS="${CFLAGS} -Werror -Wno-error=maybe-uninitialized"
+        run: make CC=${{ matrix.cc }} CFLAGS="${CFLAGS} -Werror ${{ matrix.extra_cflags }}"
         env:
           CFLAGS: -MMD -O2 -Wall -Wextra -I/opt/local/include -g

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository }}
-            ${{ secrets.DOCKER_USERNAME }}/${{ github.event.repository.name }}
+            ${{ secrets.DOCKER_USERNAME != '' && format('{0}/{1}', secrets.DOCKER_USERNAME, github.event.repository.name) || '' }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -103,6 +103,14 @@ jobs:
         run: |
           images=""
           for tag in ${TAGS}; do
-            images+="${tag}@${DIGEST} "
+            # Only sign tags for registries that were actually pushed to
+            case "${tag}" in
+              ghcr.io/*) images+="${tag}@${DIGEST} " ;;
+              */*)
+                if [ -n "${{ secrets.DOCKER_USERNAME }}" ]; then
+                  images+="${tag}@${DIGEST} "
+                fi
+                ;;
+            esac
           done
           cosign sign --yes ${images}


### PR DESCRIPTION
## Summary

- **build.yml**: `-Wno-error=maybe-uninitialized` was applied to both gcc and clang, but clang doesn't recognise that warning name and rejects it as an error under `-Werror`. Switch matrix to `include` entries so gcc gets the suppression flag and clang does not (clang builds `aes.c` cleanly without it).
- **docker-image.yml**: When `DOCKER_USERNAME` secret is unset, `${{ secrets.DOCKER_USERNAME }}/hmcfgusb` evaluates to `/hmcfgusb` — an invalid image reference that breaks the build-and-push step. Use a conditional expression to omit the DockerHub image when the secret is empty. Also guard the cosign signing loop so it only signs DockerHub tags when credentials are actually configured.

## Test plan

- [ ] Build (gcc): compiles with `-Wno-error=maybe-uninitialized`, aes.c false positives suppressed
- [ ] Build (clang): compiles with `-Werror` only, no unknown-warning-option error
- [ ] Docker push without `DOCKER_USERNAME` secret: only pushes to ghcr.io, no invalid-ref error
- [ ] Docker push with `DOCKER_USERNAME` secret: pushes to both ghcr.io and DockerHub
- [ ] Cosign signing: only signs registries that were actually pushed to

https://claude.ai/code/session_012GUFo63miXVwTirEo4ApxZ