### PR TITLE
docs: rewrite README with badges, ToC, and user-friendly structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,136 +1,196 @@
-This repository contains utilities to use the [HM-CFG-USB(2)][] (HomeMatic USB
-Konfigurations-Adapter, seems to be discontinued) from [ELV][] on Linux/Unix
-by using [libusb 1.0][].
+# hmcfgusb
 
-The HM-CFG-USB can be used to send and receive [BidCoS-Packets][] to control
-[HomeMatic][] home automation devices (like remote controllable sockets,
-switches, sensors, ...).
+Linux/Unix utilities for the **HM-CFG-USB(2)** HomeMatic USB Configuration Adapter from ELV, powered by [libusb 1.0](http://www.libusb.org/).
 
-This repository contains, amongst others, an application, which emulates the
-HomeMatic LAN configuration adapter-protocol to make it possible to use the
-HM-CFG-USB in [Fhem][] or as a lan configuration tool for the [CCU][] or the
-HomeMatic windows configuration software, also supporting devices using
-AES-signing like [KeyMatic][].
+[![Build](https://github.com/olcond/hmcfgusb/actions/workflows/build.yml/badge.svg)](https://github.com/olcond/hmcfgusb/actions/workflows/build.yml)
+[![Tests](https://github.com/olcond/hmcfgusb/actions/workflows/test.yml/badge.svg)](https://github.com/olcond/hmcfgusb/actions/workflows/test.yml)
+[![Docker Image CI](https://github.com/olcond/hmcfgusb/actions/workflows/docker-image.yml/badge.svg)](https://github.com/olcond/hmcfgusb/actions/workflows/docker-image.yml)
+[![GitHub Release](https://img.shields.io/github/v/release/olcond/hmcfgusb)](https://github.com/olcond/hmcfgusb/releases/latest)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-[HM-CFG-USB(2)]: http://www.eq-3.de/Downloads/eq3/downloads_produktkatalog/homematic/bda/HM-CFG-USB-2_-UM-eQ-3-150129-web.pdf
-[ELV]: http://www.elv.de/
-[libusb 1.0]: http://www.libusb.org/
-[BidCoS-Packets]: http://homegear.eu/index.php/BidCoS%C2%AE_Packets
-[HomeMatic]: http://www.homematic.com/
-[Fhem]: http://fhem.de/
-[KeyMatic]: http://www.elv.de/homematic-funk-tuerschlossantrieb-keymatic-silber-inkl-funk-handsender.html
-[CCU]: http://www.eq-3.de/
+---
 
-### Short hmland HowTo: ###
+## Overview
 
-1.  Install prerequisites:
-    `apt-get install libusb-1.0-0-dev build-essential clang git`
-2.  Get the current version of this software (choose **one** option):
-    *   Get the current *release*-version as a .tar.gz:
-        1.  Download the latest version from the [releases-directory][].
-            Version 0.100 is used as an example for the following commands.
-        2.  Extract the archive: `tar xzf hmcfgusb-0.100.tar.gz`
-        3.  Change into the new directory: `cd hmcfgusb-0.100`
-    *   Get the current *development*-version via git (can be easily updated with `git pull`):
-        1.  `git clone https://github.com/olcond/hmcfgusb`
-        2.  Change into the new directory: `cd hmcfgusb`
-    *   Get the current *development*-version as an archive:
-        1.  [hmcfgusb-HEAD.tar.gz][]
-        2.  Extract the archive: `tar xzf hmcfgusb-HEAD.tar.gz`
-        3.  Change into the new directory: `cd hmcfgusb-main`
-3.  Build the code: `make` (or `CC=gcc make` if clang is not available)
-4.  Optional: Install udev-rules so normal users can access the device:
-    `sudo cp hmcfgusb.rules /etc/udev/rules.d/`
-5.  Plug in the HM-CFG-USB
-6.  Run hmland (with debugging the first time, see `-h` switch):
-    `./hmland -p 1234 -D`
-7.  Configure Fhem to use your new HMLAN device:
-    ``define hmusb HMLAN 127.0.0.1:1234``
-    ``attr hmusb hmId <hmId>``
+The HM-CFG-USB allows sending and receiving [BidCoS](http://homegear.eu/index.php/BidCoS%C2%AE_Packets) packets to control [HomeMatic](http://www.homematic.com/) home automation devices — sockets, switches, sensors, and more.
 
-**Important compatibility information:**
-If older Fhem-versions (before 2015-06-19) or [Homegear][] before 2015-07-01
-is used to connect to hmland, the `-I` switch might be needed to
-impersonate a LAN-interface (this replaces the identity string HM-USB-IF with
-HM-LAN-IF). eQ-3 rfd (CCU and configuration software) works without this switch.
-Software which needs this will not keep a stable connection open to
-hmland without this switch. It was the hardcoded default in versions
-< 0.100.
+**Key features:**
 
-This incompatibility is needed so connecting software is able to
-differentiate between HM-CFG-LAN and HM-CFG-USB.
+- `hmland` — emulates the HomeMatic LAN adapter protocol for use with [Fhem](http://fhem.de/), [Homegear](https://www.homegear.eu/), and the CCU / eQ-3 configuration software
+- `hmsniff` — sniffs and displays raw BidCoS packets over the air
+- `flash-hmcfgusb` — flashes firmware to the HM-CFG-USB stick
+- `flash-ota` — over-the-air firmware updates for HomeMatic devices (supports HM-CFG-USB, CUL/COC, HM-MOD-UART)
+- AES-signed device support (e.g. [KeyMatic](http://www.elv.de/homematic-funk-tuerschlossantrieb-keymatic-silber-inkl-funk-handsender.html))
 
-**Important security information:**
-Versions before 0.101 do not correctly transmit the AES channel-mask
-to the HM-CFG-USB, which results in signature-requests not being generated
-by the device in most cases. This can lead to processing of unsigned messages
-by the host-software. If you are relying on authenticated messages
-(with e.g. aesCommReq in Fhem) from devices like door-sensors and remotes,
-you should upgrade to at least version 0.101.
+---
 
-[releases-directory]: https://github.com/olcond/hmcfgusb/releases
-[hmcfgusb-HEAD.tar.gz]: https://github.com/olcond/hmcfgusb/archive/refs/heads/main.tar.gz
-[Homegear]: https://www.homegear.eu/
+## Table of Contents
 
-### Docker: ###
+- [Installation](#installation)
+- [Quick Start — hmland](#quick-start--hmland)
+- [Docker](#docker)
+- [Flashing HM-CFG-USB Firmware](#flashing-hm-cfg-usb-firmware)
+- [Over-the-Air Device Updates](#over-the-air-device-updates)
+- [Compatibility Notes](#compatibility-notes)
+- [Security Notes](#security-notes)
+- [Credits](#credits)
 
-A pre-built Docker image is available from the GitHub Container Registry:
+---
 
+## Installation
+
+### Prerequisites
+
+```bash
+apt-get install libusb-1.0-0-dev build-essential clang git
 ```
+
+### Get the source
+
+**Latest release** (recommended for production):
+
+```bash
+# Download from https://github.com/olcond/hmcfgusb/releases/latest
+tar xzf hmcfgusb-<version>.tar.gz
+cd hmcfgusb-<version>
+```
+
+**Development version** via git:
+
+```bash
+git clone https://github.com/olcond/hmcfgusb
+cd hmcfgusb
+```
+
+**Development snapshot** (no git required):
+
+```bash
+curl -L https://github.com/olcond/hmcfgusb/archive/refs/heads/main.tar.gz | tar xz
+cd hmcfgusb-main
+```
+
+### Build
+
+```bash
+make
+# or, if clang is not available:
+CC=gcc make
+```
+
+### udev rules (optional, recommended)
+
+Allow non-root users to access the USB adapter:
+
+```bash
+sudo cp hmcfgusb.rules /etc/udev/rules.d/
+sudo udevadm control --reload-rules
+```
+
+---
+
+## Quick Start — hmland
+
+`hmland` emulates a HomeMatic LAN adapter over TCP so that home automation software can use the HM-CFG-USB directly.
+
+1. Plug in the HM-CFG-USB adapter.
+2. Start hmland (verbose mode for first run):
+
+   ```bash
+   ./hmland -p 1234 -D
+   ```
+
+3. Configure Fhem:
+
+   ```
+   define hmusb HMLAN 127.0.0.1:1234
+   attr hmusb hmId <hmId>
+   ```
+
+**Common options:**
+
+| Flag | Description |
+|------|-------------|
+| `-p <port>` | TCP listen port (default: 1000) |
+| `-D` | Debug + verbose output |
+| `-d` | Run as daemon (with PID file) |
+| `-l <file>` | Log to file |
+| `-I` | Impersonate HM-LAN-IF (see [Compatibility Notes](#compatibility-notes)) |
+
+---
+
+## Docker
+
+A pre-built multi-arch image (`amd64`, `arm64`, `arm/v7`) is available from the GitHub Container Registry:
+
+```bash
 docker pull ghcr.io/olcond/hmcfgusb
 docker run -p 1234:1234 --device /dev/bus/usb ghcr.io/olcond/hmcfgusb
 ```
 
-The image runs `hmland -v -p 1234 -I` by default.
+The container runs `hmland -v -p 1234 -I` by default and exposes port `1234`.
 
-### Updating the HM-CFG-USB firmware: ###
+---
 
-1.  Compile the hmcfgusb utilities like in the hmland HowTo above
-    (steps 1 to 5) and stay in the directory
-2.  Download the firmware update tool from [eQ-3][] and extract the
-    `.enc` firmware file from it
-3.  Make sure that hmland is not running
-4.  Flash the update to the USB-stick:
-    `./flash-hmcfgusb hmusbif.XXXX.enc` (You might need to use `sudo` for this)
+## Flashing HM-CFG-USB Firmware
 
-[eQ-3]: http://www.eq-3.de/downloads.html
+1. Build the utilities (see [Installation](#installation)).
+2. Download the firmware update from [eQ-3](http://www.eq-3.de/downloads.html) and extract the `.enc` file.
+3. Make sure `hmland` is **not** running.
+4. Flash the firmware:
 
-### Updating HomeMatic devices over the air (OTA) (also for CUL- and HM-MOD-UART-devices): ###
+   ```bash
+   ./flash-hmcfgusb hmusbif.XXXX.enc
+   # use sudo if permission is denied
+   ```
 
-1.  Compile the hmcfgusb utilities like in the hmland HowTo above
-    (steps 1 to 5) and stay in the directory
-2.  Download the new firmware from [eQ-3][], in this example the HM-CC-RT-DN
-    firmware version 1.4
-3.  Extract the tgz-file: `tar xvzf hm_cc_rt_dn_update_V1_4_001_141020.tgz`
-4.  Make sure that hmland is not running
-*   When using the **[HM-CFG-USB(2)][]**, flash the new firmware to the device
-    with serial *KEQ0123456*:
-     `./flash-ota -f hm_cc_rt_dn_update_V1_4_001_141020.eq3 -s KEQ0123456`
-*   When using a **[culfw][]**-, **[a-culfw][]**- or **[tsculfw][]**-based
-    device (**[CUL][]/[COC][]/...**), flash the new firmware to the device
-    with serial *KEQ0123456*:
-     `./flash-ota -f hm_cc_rt_dn_update_V1_4_001_141020.eq3 -s KEQ0123456 -c /dev/ttyACM0`
-*   When using the **[HM-MOD-UART][]**, flash the new firmware to the device
-    with serial *KEQ0123456*:
-     `./flash-ota -f hm_cc_rt_dn_update_V1_4_001_141020.eq3 -s KEQ0123456 -U /dev/ttyAMA0`
+---
 
-**Automatic firmware-updates:**
-The options `-C` (HMID of central), `-D` (HMID of device) and `-K` (AES key w/
-index) can be used to send a device to the bootloader automatically without
-manually rebooting the device while pressing buttons:
+## Over-the-Air Device Updates
 
-`./flash-ota -f hm_cc_rt_dn_update_V1_4_001_141020.eq3 -C ABCDEF -D 012345 -K 01:00112233445566778899AABBCCDDEEFF`
+Supports **HM-CFG-USB(2)**, [culfw](http://culfw.de/culfw.html)/[a-culfw](https://forum.fhem.de/index.php?topic=35064.0)/[tsculfw](https://forum.fhem.de/index.php?topic=24436.0)-based devices (CUL, COC, …), and **HM-MOD-UART**.
 
-`-K` is only needed, when AES signing is active on the device.
+1. Build the utilities (see [Installation](#installation)).
+2. Download the new device firmware from [eQ-3](http://www.eq-3.de/downloads.html) and extract the `.eq3` file.
+3. Make sure `hmland` is **not** running.
+4. Flash with the appropriate command for your hardware:
 
-**Acknowledgments:**
-flash-ota uses the public domain [AES implementation by Brad Conte][] to answer
-signing-requests with culfw-devices.
+   ```bash
+   # HM-CFG-USB(2)
+   ./flash-ota -f firmware.eq3 -s KEQ0123456
 
-[culfw]: http://culfw.de/culfw.html
-[a-culfw]: https://forum.fhem.de/index.php?topic=35064.0
-[tsculfw]: https://forum.fhem.de/index.php?topic=24436.0
-[CUL]: http://busware.de/tiki-index.php?page=CUL
-[COC]: http://busware.de/tiki-index.php?page=COC
-[HM-MOD-UART]: https://www.elv.de/homematic-funkmodul-fuer-raspberry-pi-bausatz.html
-[AES implementation by Brad Conte]: https://github.com/B-Con/crypto-algorithms
+   # CUL / COC (culfw-based serial device)
+   ./flash-ota -f firmware.eq3 -s KEQ0123456 -c /dev/ttyACM0
+
+   # HM-MOD-UART
+   ./flash-ota -f firmware.eq3 -s KEQ0123456 -U /dev/ttyAMA0
+   ```
+
+**Automatic bootloader entry** (no manual button press required):
+
+```bash
+./flash-ota -f firmware.eq3 -C ABCDEF -D 012345 -K 01:00112233445566778899AABBCCDDEEFF
+```
+
+`-C` = HMID of your central, `-D` = HMID of the target device, `-K` = AES key index and key (only needed if AES signing is active on the device).
+
+---
+
+## Compatibility Notes
+
+**Older Fhem / Homegear versions:**
+Fhem before 2015-06-19 and Homegear before 2015-07-01 require the `-I` flag when connecting to `hmland`. This makes hmland identify itself as `HM-LAN-IF` instead of `HM-USB-IF`. Without it, older software will not maintain a stable connection. Modern versions of Fhem, Homegear, and eQ-3 rfd work correctly without `-I`.
+
+---
+
+## Security Notes
+
+> [!WARNING]
+> Versions **before 0.101** do not correctly transmit the AES channel-mask to the HM-CFG-USB. This causes signature requests to not be generated by the device in most cases, allowing unsigned messages to be processed by host software. If you rely on authenticated messages (e.g. `aesCommReq` in Fhem) from door sensors, remotes, or similar devices, upgrade to **≥ 0.101**.
+
+---
+
+## Credits
+
+- Original author: **Michael Gernoth** &lt;michael@gernoth.net&gt; (2013–2020)
+- AES implementation: [Brad Conte](https://github.com/B-Con/crypto-algorithms) (public domain)
+- [HM-CFG-USB(2) product page](http://www.eq-3.de/Downloads/eq3/downloads_produktkatalog/homematic/bda/HM-CFG-USB-2_-UM-eQ-3-150129-web.pdf) — [ELV](http://www.elv.de/)


### PR DESCRIPTION
## Summary

- Add CI badges: Build, Tests, Docker Image CI, GitHub Release, MIT licence
- Add table of contents with anchor links
- Reorganise into clear sections: Overview · Installation · Quick Start · Docker · Firmware Flashing · OTA Updates · Compatibility · Security · Credits
- Add `hmland` options table
- Use GitHub `[!WARNING]` callout for the pre-0.101 AES security note
- Replace the large numbered list install flow with labelled, copy-friendly code blocks

https://claude.ai/code/session_012GUFo63miXVwTirEo4ApxZ