### PR TITLE
fix(ci): remove DockerHub publishing from Docker workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -39,13 +39,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to DockerHub
-        if: ${{ github.event_name != 'pull_request' && secrets.DOCKER_USERNAME != '' && secrets.DOCKER_PASSWORD != '' }}
-        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
       - name: Install Cosign
         if: ${{ github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/') || github.event_name == 'schedule' }}
         uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad # v4.0.0
@@ -60,9 +53,7 @@ jobs:
       - id: docker_meta
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5.10.0
         with:
-          images: |
-            ghcr.io/${{ github.repository }}
-            ${{ secrets.DOCKER_USERNAME != '' && format('{0}/{1}', secrets.DOCKER_USERNAME, github.event.repository.name) || '' }}
+          images: ghcr.io/${{ github.repository }}
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -103,14 +94,6 @@ jobs:
         run: |
           images=""
           for tag in ${TAGS}; do
-            # Only sign tags for registries that were actually pushed to
-            case "${tag}" in
-              ghcr.io/*) images+="${tag}@${DIGEST} " ;;
-              */*)
-                if [ -n "${{ secrets.DOCKER_USERNAME }}" ]; then
-                  images+="${tag}@${DIGEST} "
-                fi
-                ;;
-            esac
+            images+="${tag}@${DIGEST} "
           done
           cosign sign --yes ${images}


### PR DESCRIPTION
## Summary
- Remove DockerHub login step (no `DOCKER_USERNAME`/`DOCKER_PASSWORD` secrets needed)
- Remove DockerHub image references from docker/metadata-action
- Simplify cosign signing loop (no longer needs conditional DockerHub logic)
- Only publish to GitHub Container Registry (ghcr.io)

## Test plan
- [ ] Verify Docker Image CI workflow passes on this PR (build-only, no push)
- [ ] After merge, confirm push to ghcr.io succeeds on main branch

https://claude.ai/code/session_013rhFfBBGBmpy6HyL1BjMwV